### PR TITLE
[Week 1]

### DIFF
--- a/hyunsug/easy-11-tuple-to-object.ts
+++ b/hyunsug/easy-11-tuple-to-object.ts
@@ -1,0 +1,7 @@
+type TupleToObject<T extends readonly string[]> = {
+  [K in T[number]]: K;
+};
+
+const tuple = ["tesla", "model 3", "model X", "model Y"] as const;
+
+type result = TupleToObject<typeof tuple>; // expected { 'tesla': 'tesla', 'model 3': 'model 3', 'model X': 'model X', 'model Y': 'model Y'}

--- a/hyunsug/easy-14-first-of-array.ts
+++ b/hyunsug/easy-14-first-of-array.ts
@@ -1,0 +1,11 @@
+// type First<T extends any[]> = T extends [] ? never : T[0];
+type First<T extends any[]> = T extends [infer A, ...infer rest] ? A : never;
+
+// Original Question
+type arr1 = ["a", "b", "c"];
+type arr2 = [3, 2, 1];
+type arr3 = [];
+
+type head1 = First<arr1>; // expected to be 'a'
+type head2 = First<arr2>; // expected to be 3
+type head3 = First<arr3>;

--- a/hyunsug/easy-18-easy-tuple-length.ts
+++ b/hyunsug/easy-18-easy-tuple-length.ts
@@ -1,4 +1,4 @@
-type Length<T extends any[]> = T["length"];
+type Length<T extends readonly any[]> = T["length"];
 
 // Original Question
 type tesla = ["tesla", "model 3", "model X", "model Y"];

--- a/hyunsug/easy-18-easy-tuple-length.ts
+++ b/hyunsug/easy-18-easy-tuple-length.ts
@@ -1,0 +1,14 @@
+type Length<T extends any[]> = T["length"];
+
+// Original Question
+type tesla = ["tesla", "model 3", "model X", "model Y"];
+type spaceX = [
+  "FALCON 9",
+  "FALCON HEAVY",
+  "DRAGON",
+  "STARSHIP",
+  "HUMAN SPACEFLIGHT"
+];
+
+type teslaLength = Length<tesla>; // expected 4
+type spaceXLength = Length<spaceX>; // expected 5

--- a/hyunsug/easy-4-pick.ts
+++ b/hyunsug/easy-4-pick.ts
@@ -15,3 +15,5 @@ const todo: TodoPreview = {
   title: "Clean room",
   completed: false,
 };
+
+export {};

--- a/hyunsug/easy-4-pick.ts
+++ b/hyunsug/easy-4-pick.ts
@@ -1,0 +1,17 @@
+type MyPick<T, K extends keyof T> = {
+  [Key in K]: T[Key];
+};
+
+// Original Question
+interface Todo {
+  title: string;
+  description: string;
+  completed: boolean;
+}
+
+type TodoPreview = MyPick<Todo, "title" | "completed">;
+
+const todo: TodoPreview = {
+  title: "Clean room",
+  completed: false,
+};

--- a/hyunsug/easy-4-pick.ts
+++ b/hyunsug/easy-4-pick.ts
@@ -15,5 +15,3 @@ const todo: TodoPreview = {
   title: "Clean room",
   completed: false,
 };
-
-export {};

--- a/hyunsug/easy-43-easy-exclude.ts
+++ b/hyunsug/easy-43-easy-exclude.ts
@@ -1,0 +1,4 @@
+type MyExclude<T, U> = T extends U ? never : T;
+
+// Original Question
+type Result = MyExclude<"a" | "b" | "c", "a">; // 'b' | 'c'

--- a/hyunsug/easy-7-readonly.ts
+++ b/hyunsug/easy-7-readonly.ts
@@ -1,3 +1,7 @@
+type MyReadonly<T> = {
+  readonly [K in keyof T]: T[K];
+};
+
 // Original Question
 interface Todo {
   title: string;

--- a/hyunsug/easy-7-readonly.ts
+++ b/hyunsug/easy-7-readonly.ts
@@ -15,5 +15,3 @@ const todo: MyReadonly<Todo> = {
 
 todo.title = "Hello"; // Error: cannot reassign a readonly property
 todo.description = "barFoo"; // Error: cannot reassign a readonly property
-
-export {};

--- a/hyunsug/easy-7-readonly.ts
+++ b/hyunsug/easy-7-readonly.ts
@@ -1,0 +1,15 @@
+// Original Question
+interface Todo {
+  title: string;
+  description: string;
+}
+
+const todo: MyReadonly<Todo> = {
+  title: "Hey",
+  description: "foobar",
+};
+
+todo.title = "Hello"; // Error: cannot reassign a readonly property
+todo.description = "barFoo"; // Error: cannot reassign a readonly property
+
+export {};

--- a/hyunsug/week1.md
+++ b/hyunsug/week1.md
@@ -1,5 +1,11 @@
 # TS Types - Week 1
 
+## [WarmUp-Hello-World]
+
+```ts
+type HelloWorld = string;
+```
+
 ## [Easy-4-Pick](./easy-4-pick.ts)
 
 - **in** - Mapped Type 안에서 이용될 시, 객체의 키를 순회하며 새로운 타입을 정의하기 위해 이용된다.

--- a/hyunsug/week1.md
+++ b/hyunsug/week1.md
@@ -74,12 +74,20 @@ type First<T extends any[]> = T extends [infer A, ...infer rest] ? A : never;
 ## [Easy-18-Easy-Tuple-Length](./easy-18-easy-tuple-length.ts)
 
 ```ts
+// 오류
 type Length<T extends any[]> = T["length"];
+
+// 맞는 답
+type Length<T extends readonly any[]> = T["length"];
 ```
 
 type T는 Array의 부분집합이므로, Array객체의 "length" 속성을 사용할 수 있음
-단, 이 경우 T에 해당하는 튜플은 길이가 정해져 있기 때문에 T["length"]는 number 타입을 갖는 정수 리터럴 타입이 된다.
+단, 이 경우 T에 해당하는 튜플은 길이가 정해져 있기 때문에 T["length"]는 number 타입을 갖는 정수 리터럴 타입이 된다.  
 하지만, `type X = string[]`과 같이 단순한 배열인 경우 `type K = T["length"]`는 number르 나타난다.
+
+> 스터디 후 추가,
+> `any[]`를 사용하게 되면 해당 Array는 "Array"가 된다.
+> `readonly any[]`와 같이 제한된, 명시적인 "튜플"이어야 이것이 타입이 `number`로 나타나지 않는다.
 
 ## [Easy-43-Easy-Exclude](./easy-43-easy-exclude.ts)
 

--- a/hyunsug/week1.md
+++ b/hyunsug/week1.md
@@ -74,3 +74,37 @@ type Length<T extends any[]> = T["length"];
 type T는 Array의 부분집합이므로, Array객체의 "length" 속성을 사용할 수 있음
 단, 이 경우 T에 해당하는 튜플은 길이가 정해져 있기 때문에 T["length"]는 number 타입을 갖는 정수 리터럴 타입이 된다.
 하지만, `type X = string[]`과 같이 단순한 배열인 경우 `type K = T["length"]`는 number르 나타난다.
+
+## [Easy-43-Easy-Exclude](./easy-43-easy-exclude.ts)
+
+`Exclude`를 구현하는 문항, Exclude는 UnionType에서 제외할 것을 제외한 나머지를 타입으로 리턴하는 역할을 한다.
+[Exclude<UnionType, ExcludedMembers>](https://www.typescriptlang.org/docs/handbook/utility-types.html#excludeuniontype-excludedmembers)
+
+```ts
+type MyExclude<T, U> = T extends U ? never : T;
+```
+
+타입스크립트 타입 적용에 **조건부 타입의 분배 법칙**이 적용되어 유니언 T의 각 항이 개별적으로 평가된다.
+
+```ts
+type T = "a" | "b" | "c";
+
+type Result = MyExclude<T, "a">;
+
+// 이는 다음과 같이 해석, 평가된다.
+type Result =
+  | ("a" extends "a" ? never : "a")
+  | ("b" extends "a" ? never : "b")
+  | ("c" extends "a" ? never : "c");
+
+// 그리고 never가 아닌 타입들의 유니언타입으로 형성된다.
+```
+
+never가 유니언에서 제거되는 이유는 "no value"를 명시하는 타입으로, 타입스크립트에 의해 축약/제거되기 때문이다.
+[참고자료](https://www.typescripttutorial.net/typescript-tutorial/typescript-never-type/)
+
+`null`과 다른 점이라면, null은 값에 null을 가지고 있는 것이고 `never`는 정말로 값이 없는 것, 집합에서의 공집합을 의미하기 떄문이라 한다.
+
+추가로 살펴볼 것: 집합론과 함께 타입스크립트의 타입의 이해
+[자료 1](https://thoughtspile.github.io/2023/01/23/typescript-sets/)
+[자료 2](https://ivov.dev/notes/typescript-and-set-theory)

--- a/hyunsug/week1.md
+++ b/hyunsug/week1.md
@@ -64,3 +64,13 @@ type First<T extends any[]> = T extends [infer A, ...infer rest] ? A : never;
 ```
 
 이 방식은 Array의 구조분해할당을 이용하는 방식으로 첫번째 원소의 타입을 A로 추론하고 존재한다면 A를, 빈 배열이어서 존재하지 않는다면 `never`를 가지게 하는 방식이다.
+
+## [Easy-18-Easy-Tuple-Length](./easy-18-easy-tuple-length.ts)
+
+```ts
+type Length<T extends any[]> = T["length"];
+```
+
+type T는 Array의 부분집합이므로, Array객체의 "length" 속성을 사용할 수 있음
+단, 이 경우 T에 해당하는 튜플은 길이가 정해져 있기 때문에 T["length"]는 number 타입을 갖는 정수 리터럴 타입이 된다.
+하지만, `type X = string[]`과 같이 단순한 배열인 경우 `type K = T["length"]`는 number르 나타난다.

--- a/hyunsug/week1.md
+++ b/hyunsug/week1.md
@@ -1,0 +1,15 @@
+# TS Types - Week 1
+
+## Easy-4-Pick
+
+- **in** - Mapped Type 안에서 이용될 시, 객체의 키를 순회하며 새로운 타입을 정의하기 위해 이용된다.
+  - [MappedType](https://www.typescriptlang.org/ko/docs/handbook/2/mapped-types.html)
+- **extends** - `A extends B`와 같이 사용될 시, A가 B의 부분집합을 만족해야함을 의미한다.
+- `[Key in K]` - K의 각 값을 순회하며 새로운 객체 타입의 key로 이용하기 위해 사용되었다.
+- `T[Key]` - T라는 타입의 객체에서 Key에 해당하는 value의 타입을 지정한다. K가 extends를 통해 `keyof T`를 만족하므로 `Key`는 T 객체의 key이다.
+
+```ts
+type MyPick<T, K extends keyof T> = {
+  [Key in K]: T[Key];
+};
+```

--- a/hyunsug/week1.md
+++ b/hyunsug/week1.md
@@ -23,3 +23,16 @@ type MyReadonly<T> = {
   readonly [K in keyof T]: T[K];
 };
 ```
+
+## [Easy-11-Tuple-to-Object](./easy-11-tuple-to-object.ts)
+
+- **T[number]** - 배열 T의 각 요소의 타입을 지정한다.
+
+```ts
+type TupleToObject<T extends readonly string[]> = {
+  [K in T[number]]: K;
+};
+```
+
+`readonly any[]`를 생각하고 해결해보려 했으나, object의 key는 string | number | symbol이어야 했다.
+또한, 주어진 문제 자체는 `readonly string[]`타입이었기에 easy인 해당 문제는 그것을 기반으로 해결하였다.

--- a/hyunsug/week1.md
+++ b/hyunsug/week1.md
@@ -1,6 +1,6 @@
 # TS Types - Week 1
 
-## Easy-4-Pick
+## [Easy-4-Pick](./easy-4-pick.ts)
 
 - **in** - Mapped Type 안에서 이용될 시, 객체의 키를 순회하며 새로운 타입을 정의하기 위해 이용된다.
   - [MappedType](https://www.typescriptlang.org/ko/docs/handbook/2/mapped-types.html)
@@ -11,5 +11,15 @@
 ```ts
 type MyPick<T, K extends keyof T> = {
   [Key in K]: T[Key];
+};
+```
+
+## [Easy-7-Readonly](./easy-7-readonly.ts)
+
+- **readonly** - 객체의 속성이나 배열 요소를 읽기 전용으로 지정, 적용된 속성은 초기화 이후 변경될 수 없다. 인터페이스의 각 속성에도 적용할 수 있다.
+
+```ts
+type MyReadonly<T> = {
+  readonly [K in keyof T]: T[K];
 };
 ```

--- a/hyunsug/week1.md
+++ b/hyunsug/week1.md
@@ -36,3 +36,31 @@ type TupleToObject<T extends readonly string[]> = {
 
 `readonly any[]`를 생각하고 해결해보려 했으나, object의 key는 string | number | symbol이어야 했다.
 또한, 주어진 문제 자체는 `readonly string[]`타입이었기에 easy인 해당 문제는 그것을 기반으로 해결하였다.
+
+## [Easy-14-First-of-Array](./easy-14-first-of-array.ts)
+
+- 접근 첫번째
+
+T는 배열이므로 첫번째 원소를 return: 빈 배열에 대해 적합하지 않음 (타입에러 발생생)
+
+```ts
+type First<T extends any[]> = T[0];
+```
+
+- 접근 두번째
+
+T가 빈 배열이라면 원소 타입을 리턴할 수 없으니 "빈 배열 타입"인 `[]`와 비교한다.
+
+```ts
+type First<T extends any[]> = T extends [] ? never : T[0];
+```
+
+- 추가적인 방식
+
+**`infer`**: Conditional과 함께 이용되어야만 하며, 타입스크립트에 의한 타입 추론과 함께 이용한다.
+
+```ts
+type First<T extends any[]> = T extends [infer A, ...infer rest] ? A : never;
+```
+
+이 방식은 Array의 구조분해할당을 이용하는 방식으로 첫번째 원소의 타입을 A로 추론하고 존재한다면 A를, 빈 배열이어서 존재하지 않는다면 `never`를 가지게 하는 방식이다.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "isolatedModules": true
-  }
-}


### PR DESCRIPTION
warmup, easy 6개

---

아래는 깃허브 코파일럿 PR생성 테스트

This pull request introduces several TypeScript utility types and their respective implementations. The changes focus on creating custom types to handle common operations such as picking properties from an object, making properties readonly, converting tuples to objects, and more.

Key changes include:

* TypeScript Utility Types Implementations:
  * [`hyunsug/easy-4-pick.ts`](diffhunk://#diff-9530443af03e9e0ef223a4a74a35656dc6800421aecd56eaf0a1de4d293043cbR1-R17): Added `MyPick` type to pick specified properties from an object.
  * [`hyunsug/easy-7-readonly.ts`](diffhunk://#diff-beded6a706d1ef435469e2ec78e037c15e1d4fcd7c4320a143e0676072bbc802R1-R17): Added `MyReadonly` type to make all properties of an object readonly.
  * [`hyunsug/easy-11-tuple-to-object.ts`](diffhunk://#diff-0b0d399f8d8bbe79008c616ab902a58c07a07d2a5260f98c9e5a79320664f9f3R1-R7): Added `TupleToObject` type to convert a tuple to an object with tuple values as keys.
  * [`hyunsug/easy-14-first-of-array.ts`](diffhunk://#diff-32a2dfff2ce962b6c9d6150e925ea41865b657fdaf4f9cdfabed74f53911ceeeR1-R11): Added `First` type to get the first element of an array, with handling for empty arrays.
  * [`hyunsug/easy-18-easy-tuple-length.ts`](diffhunk://#diff-8b1135620dea23b2ad378985f26a20cac62d175ee8536f0734f5847f39d58dedR1-R14): Added `Length` type to get the length of a tuple.
  * [`hyunsug/easy-43-easy-exclude.ts`](diffhunk://#diff-e5b178c29cec37a4133fe010e217203f420eeeae6de91624129f33bd01dd7404R1-R4): Added `MyExclude` type to exclude specific types from a union type.

* Documentation:
  * [`hyunsug/week1.md`](diffhunk://#diff-72db576d84ed16913eac0c02ee882c2d9c76fde7d6ecf1c007646a4fc3fefaeaR1-R116): Added documentation for the implemented TypeScript utility types, explaining their usage and providing examples.